### PR TITLE
Update ROI files for panels (AV1)

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -420,55 +420,57 @@ workflow {
         SUB_PREPROCESS(fq_read_input)
     }
 
-    if (!params.panel) {        // if not params.panel =WGS
+    if (!params.preprocessOnly) {
+        if (!params.panel) { 
 
-        if (params.fastqInput||params.fastq) {
-            SUB_PREPROCESS(fq_read_input)
-            
-            if (!params.skipVariants) {
-                SUB_VARIANTCALL_WGS(SUB_PREPROCESS.out.finalAln)
+            if (params.fastqInput||params.fastq) {
+                SUB_PREPROCESS(fq_read_input)
+                
+                if (!params.skipVariants) {
+                    SUB_VARIANTCALL_WGS(SUB_PREPROCESS.out.finalAln)
+                }
+                if (!params.skipSV) {
+                    SUB_CNV_SV(SUB_PREPROCESS.out.finalAln)
+                }
+                if (!params.skipSTR) {
+                    SUB_STR(SUB_PREPROCESS.out.finalAln)
+                }
+                
+                if (!params.skipSMN) {
+                SUB_SMN(SUB_PREPROCESS.out.finalAln)
+                }
             }
-            if (!params.skipSV) {
-                SUB_CNV_SV(SUB_PREPROCESS.out.finalAln)
-            }
-            if (!params.skipSTR) {
-                SUB_STR(SUB_PREPROCESS.out.finalAln)
-            }
-            
-            if (!params.skipSMN) {
-            SUB_SMN(SUB_PREPROCESS.out.finalAln)
+
+            if (!params.fastqInput && !params.fastq) {
+                inputFiles_symlinks_cram(meta_aln_index)
+
+                if (!params.skipVariants) {
+                    SUB_VARIANTCALL_WGS(meta_aln_index)
+                }
+                if (!params.skipSV) {
+                    SUB_CNV_SV(meta_aln_index)
+                }
+                if (!params.skipSTR) {
+                    SUB_STR(meta_aln_index)
+                }
+                if (!params.skipSMN) {
+                SUB_SMN(meta_aln_index)
+                }
             }
         }
 
-        if (!params.fastqInput && !params.fastq) {
-            inputFiles_symlinks_cram(meta_aln_index)
+        if (params.panel) {
 
-            if (!params.skipVariants) {
-                SUB_VARIANTCALL_WGS(meta_aln_index)
+            if (params.fastqInput||params.fastq) {
+                SUB_PREPROCESS(fq_read_input)
+                SUB_VARIANTCALL(SUB_PREPROCESS.out.finalAln)
             }
-            if (!params.skipSV) {
-                SUB_CNV_SV(meta_aln_index)
-            }
-            if (!params.skipSTR) {
-                SUB_STR(meta_aln_index)
-            }
-            if (!params.skipSMN) {
-            SUB_SMN(meta_aln_index)
+            if (!params.fastqInput && !params.fastq) {
+                inputFiles_symlinks_cram(meta_aln_index)
+                SUB_VARIANTCALL(meta_aln_index)
             }
         }
     }
-    if (params.panel) {
-
-        if (params.fastqInput||params.fastq) {
-            SUB_PREPROCESS(fq_read_input)
-            SUB_VARIANTCALL(SUB_PREPROCESS.out.finalAln)
-        }
-        if (!params.fastqInput && !params.fastq) {
-            inputFiles_symlinks_cram(meta_aln_index)
-            SUB_VARIANTCALL(meta_aln_index)
-        }
-    }
-
 
 
 }

--- a/main.nf
+++ b/main.nf
@@ -268,7 +268,7 @@ if (params.samplesheet && params.fastq || params.fastqInput) {
 
 
 
-if (params.cram && !params.panel) {
+if (params.cram && !params.panel && !params.samplesheet) {
 
     cramfiles="${params.cram}/${reads_pattern_cram}"
     craifiles="${params.cram}/${reads_pattern_crai}"
@@ -284,7 +284,7 @@ if (params.cram && !params.panel) {
     .set {sampleID_crai }
 }
 
-if (params.cram && params.panel) {
+if (params.cram && (params.panel || params.samplesheet)) {
 
     cramfiles="${params.cram}/${reads_pattern_cram}"
     craifiles="${params.cram}/${reads_pattern_crai}"

--- a/main.nf
+++ b/main.nf
@@ -210,11 +210,8 @@ switch (params.panel) {
 ////////////////////////////////////////////////////
 ////// INPUT DATA (fastq or CRAM) channels //////////
 ////////////////////////////////////////////////////
-if (params.fastq && !params.preprocessOnly) {
+if (params.fastq) {
     params.reads="${params.fastq}/${reads_pattern_fastq}"
-}
-if (params.fastq&& params.preprocessOnly) {
-    params.reads="${params.fastq}/*{.,_,-}{R1,R2}*.gz"
 }
 
 if (!params.fastq && params.fastqInput) {
@@ -266,7 +263,7 @@ if (params.samplesheet && params.fastq || params.fastqInput) {
 }
 
 
-// Standard use: POint to fastq for WGS ana
+// Standard use: Point to fastq for WGS ana
 
 
 
@@ -419,61 +416,56 @@ workflow QC {
 
 workflow {
 
-    if (params.preprocessOnly) {
-        SUB_PREPROCESS(fq_read_input)
-    }
+    if (!params.panel) { 
 
-    if (!params.preprocessOnly) {
-        if (!params.panel) { 
-
-            if (params.fastqInput||params.fastq) {
-                SUB_PREPROCESS(fq_read_input)
-                
-                if (!params.skipVariants) {
-                    SUB_VARIANTCALL_WGS(SUB_PREPROCESS.out.finalAln)
-                }
-                if (!params.skipSV) {
-                    SUB_CNV_SV(SUB_PREPROCESS.out.finalAln)
-                }
-                if (!params.skipSTR) {
-                    SUB_STR(SUB_PREPROCESS.out.finalAln)
-                }
-                
-                if (!params.skipSMN) {
-                SUB_SMN(SUB_PREPROCESS.out.finalAln)
-                }
+        if (params.fastqInput||params.fastq) {
+            SUB_PREPROCESS(fq_read_input)
+            
+            if (!params.skipVariants) {
+                SUB_VARIANTCALL_WGS(SUB_PREPROCESS.out.finalAln)
             }
-
-            if (!params.fastqInput && !params.fastq) {
-                inputFiles_symlinks_cram(meta_aln_index)
-
-                if (!params.skipVariants) {
-                    SUB_VARIANTCALL_WGS(meta_aln_index)
-                }
-                if (!params.skipSV) {
-                    SUB_CNV_SV(meta_aln_index)
-                }
-                if (!params.skipSTR) {
-                    SUB_STR(meta_aln_index)
-                }
-                if (!params.skipSMN) {
-                SUB_SMN(meta_aln_index)
-                }
+            if (!params.skipSV) {
+                SUB_CNV_SV(SUB_PREPROCESS.out.finalAln)
+            }
+            if (!params.skipSTR) {
+                SUB_STR(SUB_PREPROCESS.out.finalAln)
+            }
+            
+            if (!params.skipSMN) {
+            SUB_SMN(SUB_PREPROCESS.out.finalAln)
             }
         }
 
-        if (params.panel) {
+        if (!params.fastqInput && !params.fastq) {
+            inputFiles_symlinks_cram(meta_aln_index)
 
-            if (params.fastqInput||params.fastq) {
-                SUB_PREPROCESS(fq_read_input)
-                SUB_VARIANTCALL(SUB_PREPROCESS.out.finalAln)
+            if (!params.skipVariants) {
+                SUB_VARIANTCALL_WGS(meta_aln_index)
             }
-            if (!params.fastqInput && !params.fastq) {
-                inputFiles_symlinks_cram(meta_aln_index)
-                SUB_VARIANTCALL(meta_aln_index)
+            if (!params.skipSV) {
+                SUB_CNV_SV(meta_aln_index)
+            }
+            if (!params.skipSTR) {
+                SUB_STR(meta_aln_index)
+            }
+            if (!params.skipSMN) {
+            SUB_SMN(meta_aln_index)
             }
         }
     }
+
+    if (params.panel) {
+
+        if (params.fastqInput||params.fastq) {
+            SUB_PREPROCESS(fq_read_input)
+            SUB_VARIANTCALL(SUB_PREPROCESS.out.finalAln)
+        }
+        if (!params.fastqInput && !params.fastq) {
+            inputFiles_symlinks_cram(meta_aln_index)
+            SUB_VARIANTCALL(meta_aln_index)
+        }
+    }
+
 
 
 }

--- a/main.nf
+++ b/main.nf
@@ -176,6 +176,15 @@ switch (params.panel) {
         panelID="CV5"
     break;
 
+    case "GV3":
+        reads_pattern_cram="*{GV1,GV2,GV3}*.cram";
+        reads_pattern_crai="*{GV1,GV2,GV3}*.crai";
+        reads_pattern_fastq="*{GV1,GV2,GV3}*R{1,2}*{fq,fastq}.gz";
+        panelID="GV3"
+    break;
+
+
+
     case "WES_2":
         reads_pattern_cram="*{-,.,_}{EV8,EV7,EV6}{-,.,_}*.cram";
         reads_pattern_crai="*{-,.,_}{EV8,EV7,EV6}{-,.,_}*.crai";

--- a/main.nf
+++ b/main.nf
@@ -210,8 +210,11 @@ switch (params.panel) {
 ////////////////////////////////////////////////////
 ////// INPUT DATA (fastq or CRAM) channels //////////
 ////////////////////////////////////////////////////
-if (params.fastq) {
+if (params.fastq && !params.preprocessOnly) {
     params.reads="${params.fastq}/${reads_pattern_fastq}"
+}
+if (params.fastq&& params.preprocessOnly) {
+    params.reads="${params.fastq}/*{.,_,-}{R1,R2}*.gz"
 }
 
 if (!params.fastq && params.fastqInput) {

--- a/modules/modules.dna.v1.nf
+++ b/modules/modules.dna.v1.nf
@@ -171,6 +171,11 @@ switch (params.panel) {
         panelID="CV5"
     break;
 
+    case "GV3":
+        ROI="${GV3_ROI}";
+        panelID="GV3"
+    break;
+
     case "WES_2":
         ROI="${WES_ROI}";
         panelID="WES"

--- a/modules/modules.dna.v1.nf
+++ b/modules/modules.dna.v1.nf
@@ -147,13 +147,13 @@ switch (params.genome) {
 
         hapmap="/data/shared/genomes/hg38/program_DBs/GATK/resources_broad_hg38_v0_hapmap_3.3.hg38.vcf.gz"
         omni="/data/shared/genomes/hg38/program_DBs/GATK/resources_broad_hg38_v0_1000G_omni2.5.hg38.vcf.gz"
-        AV1_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/av1.hg38.ROI.bed"
+        AV1_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/av1.hg38.ROI.v2.bed"
         CV1_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/cv3.hg38.ROI.bed"
         CV2_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/cv3.hg38.ROI.bed"
         CV3_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/cv3.hg38.ROI.bed"
         CV4_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/cv4.hg38.ROI.bed"
         CV5_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/cv5.hg38.ROI.bed"
-        GV3_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/gv3.hg38.ROI.bed"
+        GV3_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/gv3.hg38.ROI.v2.bed"
         NV1_ROI="/data/shared/genomes/${params.genome}/interval.files/panels/nv1.hg38.ROI.bed"
         WES_ROI="/data/shared/genomes/hg38/interval.files/exome.ROIs/211130.hg38.refseq.gencode.fullexons.50bp.SM.bed"
 


### PR DESCRIPTION
Update to AV1 ROI version 2, adding two CFTR non-exonic regions and app. 333 regions used for polygenic risk scores.